### PR TITLE
support utf-8 names and paths

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -27,6 +27,10 @@ func Parse(reader io.Reader) (*Torrent, error) {
 		return nil, err
 	}
 
+	if len(info.NameUtf8) != 0 {
+		info.Name = info.NameUtf8
+	}
+
 	files := make([]*File, 0)
 
 	// single file context
@@ -43,6 +47,9 @@ func Parse(reader io.Reader) (*Torrent, error) {
 		}
 
 		for _, f := range metadataFiles {
+			if len(f.PathUtf8) != 0 {
+				f.Path = f.PathUtf8
+			}
 			files = append(files, &File{
 				Path:   append([]string{info.Name}, f.Path...),
 				Length: f.Length,

--- a/types.go
+++ b/types.go
@@ -8,6 +8,7 @@ import (
 
 type FileMetadata struct {
 	Path   []string `bencode:"path"`
+	PathUtf8   []string `bencode:"path.utf-8"`
 	Length int64    `bencode:"length"`
 }
 
@@ -17,6 +18,7 @@ type InfoMetadata struct {
 
 	// single file context
 	Name   string `bencode:"name"`
+	NameUtf8   string `bencode:"name.utf-8"`
 	Length int64  `bencode:"length"`
 
 	// multi file context


### PR DESCRIPTION
some torrent sites use name.utf-8 and path.utf-8, if path or file name is not ascii.